### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "lodash": "~2.4.1",
     "chai": "~1.8.1",
-    "mocha": "~1.16.2",
+    "mocha": "~3.0.0",
     "handlebars": "~1.2.1",
     "sha1": "~1.1.0",
     "commander": "~2.1.0",


### PR DESCRIPTION
fluid is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `mocha`

This PR fixes the ReDoS vulnerability by upgrading `mocha` to version 3.0.0.

Check out the [Snyk test report](https://snyk.io/test/github/penman/fluid) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
